### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 4'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/chcg/SpeechPlugin/security/code-scanning/3](https://github.com/chcg/SpeechPlugin/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/codeql-analysis.yml` at the workflow root (best single change), so it applies to all jobs unless overridden.  
For this workflow, start with least privilege:

- `contents: read` (minimal recommended baseline; required for checkout/repo read operations)
- `security-events: write` (needed by CodeQL analysis to upload results to code scanning)

Place this block after the trigger section (`on:`...) and before `jobs:`. This keeps functionality intact while limiting token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
