### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -2,8 +2,13 @@ name: CI_build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write
 
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/chcg/SpeechPlugin/security/code-scanning/2](https://github.com/chcg/SpeechPlugin/security/code-scanning/2)

Add explicit `permissions` to the workflow so token scope is documented and constrained.

Best fix for this file:
1. Set root-level permissions to minimal read access:
   - `contents: read` (satisfies checkout and general read operations).
2. Override permissions on the `build` job to include only what this job needs for creating releases:
   - `contents: write` (required by `softprops/action-gh-release` to create/update releases and upload release assets).

This preserves existing behavior while removing reliance on potentially broad default token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
